### PR TITLE
Bump loom to version 0.5.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ event-listener = "2.4.0"
 spinny = "0.2"
 
 [target.'cfg(loom)'.dependencies]
-loom = { version = "0.3.5", features = ["futures"] }
+loom = { version = "0.5.6", features = ["futures"] }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time", "blocking"] }


### PR DESCRIPTION
`loom:0.3.5` depends on an old version of the `generator` crate (< 0.7.0) which had a bug which could produce data races.

`loom:0.5.6` depends on `generator:0.7.0` which includes the following fix:
https://github.com/Xudong-Huang/generator-rs/commit/f7d120a3b724d06a7b623d0a4306acf8f78cb4f0.

---

I don't think this is critical, but we get a GitHub security alert on `itchysats` because of this.